### PR TITLE
Add lobby chat panel

### DIFF
--- a/Assets/Scripts/LobbyUIScripts/LobbyChatUI.cs
+++ b/Assets/Scripts/LobbyUIScripts/LobbyChatUI.cs
@@ -1,0 +1,162 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class LobbyChatUI : MonoBehaviour
+{
+    [Header("Chat UI")]
+    [SerializeField] private TMP_InputField chatInputField;
+    [SerializeField] private TextMeshProUGUI chatHistoryText;
+    [SerializeField] private Button sendButton;
+    [SerializeField] private ScrollRect scrollRect;
+
+    [Header("Scroll Settings")]
+    [SerializeField] private bool alwaysAutoScrollToBottom = true;
+
+    private LobbyState _lobbyState;
+    private int _lastSeenChatVersion = -1;
+    private float _findTimer;
+    private bool _shouldScrollToBottom;
+
+    private void Awake()
+    {
+        if (sendButton != null)
+            sendButton.onClick.AddListener(SendCurrentMessage);
+
+        if (chatInputField != null)
+            chatInputField.onSubmit.AddListener(OnInputSubmit);
+
+        ClearChatView();
+    }
+
+    private void OnEnable()
+    {
+        _lobbyState = null;
+        _lastSeenChatVersion = -1;
+        _findTimer = 0f;
+        _shouldScrollToBottom = true;
+
+        TryFindLobbyState();
+        RefreshChat(true);
+    }
+
+    private void OnDestroy()
+    {
+        if (sendButton != null)
+            sendButton.onClick.RemoveListener(SendCurrentMessage);
+
+        if (chatInputField != null)
+            chatInputField.onSubmit.RemoveListener(OnInputSubmit);
+    }
+
+    private void Update()
+    {
+        if (_lobbyState == null)
+        {
+            _findTimer += Time.unscaledDeltaTime;
+
+            if (_findTimer >= 0.25f)
+            {
+                _findTimer = 0f;
+                TryFindLobbyState();
+            }
+        }
+
+        RefreshChat(false);
+
+        if (_shouldScrollToBottom)
+        {
+            _shouldScrollToBottom = false;
+            ScrollToBottom();
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (_shouldScrollToBottom)
+        {
+            _shouldScrollToBottom = false;
+            ScrollToBottom();
+        }
+    }
+
+    private void TryFindLobbyState()
+    {
+        _lobbyState = FindObjectOfType<LobbyState>();
+    }
+
+    private void OnInputSubmit(string value)
+    {
+        SendCurrentMessage();
+    }
+
+    public void SendCurrentMessage()
+    {
+        if (chatInputField == null)
+            return;
+
+        string message = chatInputField.text;
+
+        if (string.IsNullOrWhiteSpace(message))
+            return;
+
+        if (_lobbyState == null)
+            TryFindLobbyState();
+
+        if (_lobbyState == null)
+        {
+            Debug.LogWarning("LobbyChatUI: LobbyState bulunamadı, mesaj gönderilemedi.");
+            return;
+        }
+
+        _lobbyState.RPC_SendChatMessage(message);
+
+        chatInputField.text = string.Empty;
+        chatInputField.ActivateInputField();
+
+        _shouldScrollToBottom = true;
+    }
+
+    private void RefreshChat(bool force)
+    {
+        if (_lobbyState == null)
+        {
+            if (force)
+                ClearChatView();
+
+            return;
+        }
+
+        if (!force && _lastSeenChatVersion == _lobbyState.ChatMessageVersion)
+            return;
+
+        _lastSeenChatVersion = _lobbyState.ChatMessageVersion;
+
+        if (chatHistoryText != null)
+            chatHistoryText.text = _lobbyState.GetChatLog();
+
+        if (alwaysAutoScrollToBottom || force)
+            _shouldScrollToBottom = true;
+    }
+
+    private void ClearChatView()
+    {
+        if (chatHistoryText != null)
+            chatHistoryText.text = string.Empty;
+    }
+
+    private void ScrollToBottom()
+    {
+        if (scrollRect == null)
+            return;
+
+        Canvas.ForceUpdateCanvases();
+
+        if (scrollRect.content != null)
+            LayoutRebuilder.ForceRebuildLayoutImmediate(scrollRect.content);
+
+        scrollRect.verticalNormalizedPosition = 0f;
+
+        Canvas.ForceUpdateCanvases();
+    }
+}

--- a/Assets/Scripts/LobbyUIScripts/LobbyChatUI.cs.meta
+++ b/Assets/Scripts/LobbyUIScripts/LobbyChatUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 352d11e49c85f654e9ecebc8bb3d9a79

--- a/Assets/Scripts/LobbyUIScripts/LobbyState.cs
+++ b/Assets/Scripts/LobbyUIScripts/LobbyState.cs
@@ -1,9 +1,13 @@
+using System.Text;
 using Fusion;
 using UnityEngine;
 
 public class LobbyState : NetworkBehaviour
 {
     private const int MaxPlayers = 4;
+
+    private const int ChatMaxMessageLength = 120;
+    private const int ChatLineCapacity = 180;
 
     [Header("Lobby State")]
     [Networked] public PlayerRef Slot1Player { get; set; }
@@ -19,6 +23,20 @@ public class LobbyState : NetworkBehaviour
     [Networked] public NetworkBool Slot4Ready { get; set; }
 
     [Networked] public NetworkBool GameStarted { get; set; }
+
+    [Header("Lobby Chat")]
+    [Networked] public int ChatMessageVersion { get; set; }
+
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine1 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine2 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine3 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine4 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine5 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine6 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine7 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine8 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine9 { get; set; }
+    [Networked, Capacity(ChatLineCapacity)] public string ChatLine10 { get; set; }
 
     public struct LobbySlotData
     {
@@ -447,6 +465,76 @@ public class LobbyState : NetworkBehaviour
     }
 
     // ==================================================
+    // LOBBY CHAT
+    // ==================================================
+
+    public string GetChatLog()
+    {
+        StringBuilder builder = new StringBuilder();
+
+        AppendChatLine(builder, ChatLine1);
+        AppendChatLine(builder, ChatLine2);
+        AppendChatLine(builder, ChatLine3);
+        AppendChatLine(builder, ChatLine4);
+        AppendChatLine(builder, ChatLine5);
+        AppendChatLine(builder, ChatLine6);
+        AppendChatLine(builder, ChatLine7);
+        AppendChatLine(builder, ChatLine8);
+        AppendChatLine(builder, ChatLine9);
+        AppendChatLine(builder, ChatLine10);
+
+        return builder.ToString();
+    }
+
+    private void AppendChatLine(StringBuilder builder, string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return;
+
+        if (builder.Length > 0)
+            builder.AppendLine();
+
+        builder.Append(line);
+    }
+
+    private void PushChatLine(string newLine)
+    {
+        if (!HasStateAuthority)
+            return;
+
+        ChatLine1 = ChatLine2;
+        ChatLine2 = ChatLine3;
+        ChatLine3 = ChatLine4;
+        ChatLine4 = ChatLine5;
+        ChatLine5 = ChatLine6;
+        ChatLine6 = ChatLine7;
+        ChatLine7 = ChatLine8;
+        ChatLine8 = ChatLine9;
+        ChatLine9 = ChatLine10;
+        ChatLine10 = newLine;
+
+        ChatMessageVersion++;
+    }
+
+    private string SanitizeChatMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return string.Empty;
+
+        message = message.Replace("\r", " ");
+        message = message.Replace("\n", " ");
+        message = message.Trim();
+
+        while (message.Contains("  "))
+            message = message.Replace("  ", " ");
+
+        if (message.Length > ChatMaxMessageLength)
+            message = message.Substring(0, ChatMaxMessageLength);
+
+        return message;
+    }
+
+    // ==================================================
     // RPC CALLS
     // ==================================================
 
@@ -470,6 +558,40 @@ public class LobbyState : NetworkBehaviour
             return;
 
         TogglePlayerReadyServer(sender);
+    }
+
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    public void RPC_SendChatMessage(string rawMessage, RpcInfo info = default)
+    {
+        if (!HasStateAuthority)
+            return;
+
+        PlayerRef sender = info.Source;
+
+        if (sender == default && Runner != null)
+            sender = Runner.LocalPlayer;
+
+        if (sender == default)
+            return;
+
+        if (!ContainsPlayer(sender))
+            return;
+
+        string cleanMessage = SanitizeChatMessage(rawMessage);
+
+        if (string.IsNullOrWhiteSpace(cleanMessage))
+            return;
+
+        int slotIndex = GetPlayerSlotIndex(sender);
+
+        if (slotIndex < 0)
+            return;
+
+        string line = $"Player {slotIndex + 1}: {cleanMessage}";
+
+        PushChatLine(line);
+
+        Debug.Log($"Lobby chat message: {line}");
     }
 
     [Rpc(RpcSources.All, RpcTargets.StateAuthority)]


### PR DESCRIPTION
Implemented lobby chat panel for Photon Fusion multiplayer lobby.

Changes:
- Added networked lobby chat state to LobbyState
- Added 10-message chat history limit
- Added player slot based chat labels such as Player 1, Player 2
- Added LobbyChatUI for input, send button, chat history refresh, and auto-scroll
- Updated lobby scene UI with chat panel