### PR TITLE
Add player respawn foundation

### DIFF
--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -396,6 +396,54 @@ public class PlayerMovement : NetworkBehaviour
         ApplyExternalVelocity(impulse);
     }
 
+    public void ResetMovementForRespawn(Vector3 position, Quaternion rotation)
+    {
+        if (!HasStateAuthority)
+            return;
+
+        if (rb == null)
+            rb = GetComponent<Rigidbody>();
+
+        if (capsule == null)
+            capsule = GetComponent<CapsuleCollider>();
+
+        transform.SetPositionAndRotation(position, rotation);
+
+        if (rb != null)
+        {
+            rb.position = position;
+            rb.rotation = rotation;
+            rb.angularVelocity = Vector3.zero;
+
+#if UNITY_6000_0_OR_NEWER
+            rb.linearVelocity = Vector3.zero;
+#else
+            rb.velocity = Vector3.zero;
+#endif
+        }
+
+        isMovementAllowed = true;
+        VerticalVelocity = groundedGravity;
+        JumpGroundIgnoreTimer = 0f;
+        PreviousButtons = default;
+
+        CurrentMoveInput = Vector2.zero;
+        CurrentSpeed01 = 0f;
+        CurrentGrounded = true;
+        CurrentVerticalVelocity = groundedGravity;
+        CurrentCrouching = false;
+        CurrentSprinting = false;
+
+        NetMoveInput = Vector2.zero;
+        NetSpeed01 = 0f;
+        NetGrounded = true;
+        NetVerticalVelocity = groundedGravity;
+        NetCrouching = false;
+        NetSprinting = false;
+
+        SetupCollider(false);
+    }
+
     public void SetMovementAllowed(bool value)
     {
         isMovementAllowed = value;

--- a/Assets/Scripts/PlayerSpawner.cs
+++ b/Assets/Scripts/PlayerSpawner.cs
@@ -261,6 +261,118 @@ public class PlayerSpawner : MonoBehaviour, INetworkRunnerCallbacks
         return spawnPoints[indexHint];
     }
 
+    public void TryRespawnAllPlayers()
+    {
+        if (!TryCacheRunner())
+        {
+            Debug.LogError("PlayerSpawner: NetworkRunner bulunamadı.");
+            return;
+        }
+
+        if (!_runner.IsServer)
+            return;
+
+        List<PlayerRef> activePlayers = new List<PlayerRef>(_runner.ActivePlayers);
+
+        if (activePlayers.Count == 0)
+        {
+            Debug.LogWarning("PlayerSpawner: Respawn edilecek aktif oyuncu yok.");
+            return;
+        }
+
+        activePlayers.Sort((a, b) => a.PlayerId.CompareTo(b.PlayerId));
+
+        for (int i = 0; i < activePlayers.Count; i++)
+            TryRespawnPlayer(activePlayers[i], i);
+    }
+
+    public void TryRespawnPlayer(PlayerRef player)
+    {
+        TryRespawnPlayer(player, GetSortedPlayerIndex(player));
+    }
+
+    private void TryRespawnPlayer(PlayerRef player, int indexHint)
+    {
+        if (_runner == null || !_runner.IsServer)
+            return;
+
+        if (player == default)
+            return;
+
+        NetworkObject spawnedObject = GetSpawnedPlayerObject(player);
+
+        if (spawnedObject == null)
+        {
+            Debug.LogWarning($"PlayerSpawner: Player {player.PlayerId} respawn edilemedi çünkü player object bulunamadı.");
+            return;
+        }
+
+        Transform spawnPoint = GetSpawnPoint(indexHint);
+
+        Vector3 spawnPosition = spawnPoint != null
+            ? spawnPoint.position
+            : Vector3.zero;
+
+        spawnPosition.y += spawnYOffset;
+
+        Quaternion spawnRotation = spawnPoint != null
+            ? spawnPoint.rotation
+            : Quaternion.identity;
+
+        PlayerMovement movement = spawnedObject.GetComponent<PlayerMovement>();
+
+        if (movement != null)
+            movement.ResetMovementForRespawn(spawnPosition, spawnRotation);
+        else
+            ForceSpawnTransform(spawnedObject, spawnPosition, spawnRotation);
+
+        PlayerHealth health = spawnedObject.GetComponent<PlayerHealth>();
+
+        if (health != null)
+            health.ResetHealth();
+
+        Debug.Log($"PlayerSpawner: Player {player.PlayerId} respawn edildi.");
+    }
+
+    private NetworkObject GetSpawnedPlayerObject(PlayerRef player)
+    {
+        if (_spawnedPlayers.TryGetValue(player, out NetworkObject spawnedObject) && spawnedObject != null)
+            return spawnedObject;
+
+        if (_runner == null)
+            return null;
+
+        spawnedObject = _runner.GetPlayerObject(player);
+
+        if (spawnedObject != null)
+            _spawnedPlayers[player] = spawnedObject;
+
+        return spawnedObject;
+    }
+
+    private int GetSortedPlayerIndex(PlayerRef player)
+    {
+        if (_runner == null)
+            return 0;
+
+        List<PlayerRef> activePlayers = new List<PlayerRef>(_runner.ActivePlayers);
+        activePlayers.Sort((a, b) => a.PlayerId.CompareTo(b.PlayerId));
+
+        for (int i = 0; i < activePlayers.Count; i++)
+        {
+            if (activePlayers[i] == player)
+                return i;
+        }
+
+        return 0;
+    }
+
+    [ContextMenu("Debug Respawn All Players")]
+    private void DebugRespawnAllPlayers()
+    {
+        TryRespawnAllPlayers();
+    }
+
     private void DespawnPlayer(PlayerRef player)
     {
         if (_runner == null || !_runner.IsServer)


### PR DESCRIPTION
Added respawn support for player movement and player spawning.

Changes:
- Player movement state can be reset on respawn.
- Vertical velocity and jump state are cleared during respawn.
- Eliminated players can move again after respawn.
- PlayerSpawner can respawn one player or all players.
- Respawn restores health and moves players back to spawn points.

Tested with a temporary DamageVolume:
- Player can take damage.
- Player is eliminated at 0 HP.
- Eliminated player cannot move.
- Debug respawn restores health.
- Player can move again after respawn.
- No red console errors observed.