### PR TITLE
Add TPS camera controller

### DIFF
--- a/Assets/Scripts/Camera/CameraFollowRig.cs
+++ b/Assets/Scripts/Camera/CameraFollowRig.cs
@@ -137,6 +137,13 @@ public class CameraFollowRig : MonoBehaviour
 
     private void HandleCursorState()
     {
+        if (PauseMenuManager.IsPaused)
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+            return;
+        }
+
         if (unlockCursorWithEscape && IsEscapePressed())
         {
             Cursor.lockState = CursorLockMode.None;
@@ -149,6 +156,9 @@ public class CameraFollowRig : MonoBehaviour
 
     private void HandleMouseLook()
     {
+        if (PauseMenuManager.IsPaused)
+            return;
+
         if (Cursor.lockState != CursorLockMode.Locked)
             return;
 

--- a/Assets/Scripts/Camera/CameraFollowRig.cs
+++ b/Assets/Scripts/Camera/CameraFollowRig.cs
@@ -1,23 +1,55 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class CameraFollowRig : MonoBehaviour
 {
+    public static CameraFollowRig LocalRig { get; private set; }
+
     [Header("Follow Target")]
     [SerializeField] private Transform target;
 
-    [Header("Camera Offset")]
-    [SerializeField] private Vector3 offset = new Vector3(0f, 4f, -6f);
+    [Header("Orbit")]
+    [SerializeField] private float distance = 6f;
+    [SerializeField] private float shoulderOffset = 0.35f;
+    [SerializeField] private Vector3 lookOffset = new Vector3(0f, 1.4f, 0f);
+    [SerializeField] private float mouseSensitivityX = 0.08f;
+    [SerializeField] private float mouseSensitivityY = 0.07f;
+    [SerializeField] private float minPitch = -25f;
+    [SerializeField] private float maxPitch = 65f;
+    [SerializeField] private bool invertY = false;
 
     [Header("Smoothing")]
     [SerializeField] private float followSpeed = 18f;
     [SerializeField] private float lookSpeed = 20f;
     [SerializeField] private float snapDistance = 12f;
 
-    [Header("Look")]
-    [SerializeField] private bool lookAtTarget = true;
-    [SerializeField] private Vector3 lookOffset = new Vector3(0f, 1.2f, 0f);
+    [Header("Cursor")]
+    [SerializeField] private bool lockCursorOnTarget = true;
+    [SerializeField] private bool unlockCursorWithEscape = true;
+    [SerializeField] private bool relockCursorWithLeftClick = true;
+
+    [Header("Collision")]
+    [SerializeField] private bool avoidWallClipping = false;
+    [SerializeField] private float collisionRadius = 0.25f;
+    [SerializeField] private LayerMask collisionMask = ~0;
 
     private bool hasTarget;
+    private float yaw;
+    private float pitch = 18f;
+
+    public float CurrentYaw => yaw;
+
+    public static bool TryGetLocalYaw(out float localYaw)
+    {
+        if (LocalRig == null)
+        {
+            localYaw = 0f;
+            return false;
+        }
+
+        localYaw = LocalRig.CurrentYaw;
+        return true;
+    }
 
     public void SetTarget(Transform newTarget, bool snapInstantly = true)
     {
@@ -38,6 +70,12 @@ public class CameraFollowRig : MonoBehaviour
             return;
         }
 
+        LocalRig = this;
+        SetYawFromTarget();
+
+        if (lockCursorOnTarget)
+            LockCursor();
+
         if (snapInstantly)
         {
             transform.position = GetDesiredPosition();
@@ -47,16 +85,31 @@ public class CameraFollowRig : MonoBehaviour
         Debug.Log($"CameraFollowRig: target assigned -> {target.name}");
     }
 
+    private void OnDisable()
+    {
+        if (LocalRig == this)
+            LocalRig = null;
+    }
+
+    private void OnDestroy()
+    {
+        if (LocalRig == this)
+            LocalRig = null;
+    }
+
     private void LateUpdate()
     {
         if (!hasTarget || target == null)
             return;
 
+        HandleCursorState();
+        HandleMouseLook();
+
         float deltaTime = Mathf.Max(Time.deltaTime, 0.0001f);
         Vector3 desiredPosition = GetDesiredPosition();
-        float distance = Vector3.Distance(transform.position, desiredPosition);
+        float distanceToTarget = Vector3.Distance(transform.position, desiredPosition);
 
-        if (distance > snapDistance)
+        if (distanceToTarget > snapDistance)
         {
             transform.position = desiredPosition;
         }
@@ -69,18 +122,136 @@ public class CameraFollowRig : MonoBehaviour
         ApplyLookRotation(false, deltaTime);
     }
 
+    private void SetYawFromTarget()
+    {
+        Vector3 forward = target.forward;
+        forward.y = 0f;
+
+        if (forward.sqrMagnitude > 0.001f)
+            yaw = Quaternion.LookRotation(forward.normalized, Vector3.up).eulerAngles.y;
+        else
+            yaw = transform.eulerAngles.y;
+
+        pitch = Mathf.Clamp(pitch, minPitch, maxPitch);
+    }
+
+    private void HandleCursorState()
+    {
+        if (unlockCursorWithEscape && IsEscapePressed())
+        {
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+        }
+
+        if (relockCursorWithLeftClick && IsLeftMousePressed())
+            LockCursor();
+    }
+
+    private void HandleMouseLook()
+    {
+        if (Cursor.lockState != CursorLockMode.Locked)
+            return;
+
+        Vector2 mouseDelta = GetMouseDelta();
+
+        if (mouseDelta.sqrMagnitude <= 0.001f)
+            return;
+
+        yaw += mouseDelta.x * mouseSensitivityX;
+
+        float yDirection = invertY ? 1f : -1f;
+        pitch += mouseDelta.y * mouseSensitivityY * yDirection;
+        pitch = Mathf.Clamp(pitch, minPitch, maxPitch);
+    }
+
+    private Vector2 GetMouseDelta()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (Mouse.current != null)
+            return Mouse.current.delta.ReadValue();
+#endif
+
+#if ENABLE_LEGACY_INPUT_MANAGER
+        return new Vector2(Input.GetAxisRaw("Mouse X") * 12f, Input.GetAxisRaw("Mouse Y") * 12f);
+#else
+        return Vector2.zero;
+#endif
+    }
+
+    private bool IsEscapePressed()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (Keyboard.current != null && Keyboard.current.escapeKey.wasPressedThisFrame)
+            return true;
+#endif
+
+#if ENABLE_LEGACY_INPUT_MANAGER
+        return Input.GetKeyDown(KeyCode.Escape);
+#else
+        return false;
+#endif
+    }
+
+    private bool IsLeftMousePressed()
+    {
+#if ENABLE_INPUT_SYSTEM
+        if (Mouse.current != null && Mouse.current.leftButton.wasPressedThisFrame)
+            return true;
+#endif
+
+#if ENABLE_LEGACY_INPUT_MANAGER
+        return Input.GetMouseButtonDown(0);
+#else
+        return false;
+#endif
+    }
+
+    private void LockCursor()
+    {
+        Cursor.lockState = CursorLockMode.Locked;
+        Cursor.visible = false;
+    }
+
     private Vector3 GetDesiredPosition()
     {
-        return target.position + offset;
+        Vector3 lookPoint = GetLookPoint();
+        Quaternion orbitRotation = Quaternion.Euler(pitch, yaw, 0f);
+        Vector3 desiredPosition = lookPoint + orbitRotation * new Vector3(shoulderOffset, 0f, -distance);
+
+        if (!avoidWallClipping)
+            return desiredPosition;
+
+        Vector3 toCamera = desiredPosition - lookPoint;
+        float castDistance = toCamera.magnitude;
+
+        if (castDistance <= 0.01f)
+            return desiredPosition;
+
+        Vector3 direction = toCamera / castDistance;
+
+        if (Physics.SphereCast(
+            lookPoint,
+            collisionRadius,
+            direction,
+            out RaycastHit hit,
+            castDistance,
+            collisionMask,
+            QueryTriggerInteraction.Ignore))
+        {
+            return hit.point - direction * collisionRadius;
+        }
+
+        return desiredPosition;
+    }
+
+    private Vector3 GetLookPoint()
+    {
+        return target.position + lookOffset;
     }
 
     private void ApplyLookRotation(bool instant, float deltaTime)
     {
-        if (!lookAtTarget || target == null)
-            return;
-
-        Vector3 lookPoint = target.position + lookOffset;
-        Vector3 direction = lookPoint - transform.position;
+        Vector3 direction = GetLookPoint() - transform.position;
 
         if (direction.sqrMagnitude <= 0.001f)
             return;

--- a/Assets/Scripts/Network/NetworkRunnerHandler.cs
+++ b/Assets/Scripts/Network/NetworkRunnerHandler.cs
@@ -246,6 +246,11 @@ public class NetworkRunnerHandler : MonoBehaviour, INetworkRunnerCallbacks
         inputData.Buttons.Set((int)PlayerInputButton.Sprint, sprint);
         inputData.Buttons.Set((int)PlayerInputButton.Crouch, crouch);
 
+        if (CameraFollowRig.TryGetLocalYaw(out float cameraYaw))
+            inputData.CameraYaw = cameraYaw;
+        else
+            inputData.CameraYaw = 0f;
+
         input.Set(inputData);
     }
 

--- a/Assets/Scripts/Network/PlayerNetworkInputData.cs
+++ b/Assets/Scripts/Network/PlayerNetworkInputData.cs
@@ -12,4 +12,5 @@ public struct PlayerNetworkInputData : INetworkInput
 {
     public Vector2 MoveInput;
     public NetworkButtons Buttons;
+    public float CameraYaw;
 }

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -174,7 +174,7 @@ public class PlayerMovement : NetworkBehaviour
             speed = crouchSpeed;
 
         Vector3 moveDirection = isMovementAllowed
-            ? new Vector3(moveInput.x, 0f, moveInput.y)
+            ? GetCameraRelativeMoveDirection(moveInput, inputData.CameraYaw)
             : Vector3.zero;
 
         verticalVelocity += gravity * deltaTime;
@@ -294,6 +294,33 @@ public class PlayerMovement : NetworkBehaviour
             crouching ? crouchingCapsuleCenterY : standingCapsuleCenterY,
             0f
         );
+    }
+
+
+    private Vector3 GetCameraRelativeMoveDirection(Vector2 input, float cameraYaw)
+    {
+        if (input.sqrMagnitude <= 0.001f)
+            return Vector3.zero;
+
+        Quaternion yawRotation = Quaternion.Euler(0f, cameraYaw, 0f);
+        Vector3 forward = yawRotation * Vector3.forward;
+        Vector3 right = yawRotation * Vector3.right;
+
+        forward.y = 0f;
+        right.y = 0f;
+
+        if (forward.sqrMagnitude > 0.001f)
+            forward.Normalize();
+
+        if (right.sqrMagnitude > 0.001f)
+            right.Normalize();
+
+        Vector3 direction = right * input.x + forward * input.y;
+
+        if (direction.sqrMagnitude > 1f)
+            direction.Normalize();
+
+        return direction;
     }
 
     private bool CheckGround(Vector3 rootPosition, out RaycastHit hit)


### PR DESCRIPTION
Added a mouse-controlled third-person camera and camera-relative player movement.

Tested:
- Mouse orbit camera works.
- WASD movement follows camera direction.
- Jump still works.
- Movement remains smooth on build client.
- Pause menu remains clickable after pressing Escape.
- Resume restores gameplay camera control.
- No red console errors observed.